### PR TITLE
Make Safari break URLs

### DIFF
--- a/txt.css
+++ b/txt.css
@@ -360,3 +360,7 @@ address .tel, address .email {
 address .tel + .email {
   margin: 0;
 }
+/* Safari doesn't seem to break long words (URLs) on slashes, so force a break */
+a {
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
Safari doesn't seem to break long words (URLs) on slashes, so force a break