### PR TITLE
Make the header look more like the text rendering

### DIFF
--- a/txt.css
+++ b/txt.css
@@ -156,28 +156,40 @@ blockquote {
   #identifiers dd {
     grid-column: 1;
   }
-  #identifiers dd.authors {
-    grid-area: 1 / 2 / 100 / 3;
+  #identifiers dd:is(.published, .authors) {
+    display: block;
     width: 24ch;
     text-align: right;
-    display: block;
     /* overrides for @supports not block */
     padding-left: 0;
   }
-  /* more overrides for @supports not block */
-  #identifiers dd.authors::before {
-    display: none;
+  #identifiers dd.published {
+    grid-area: -2 / 2 / -1 / 3;
+  }
+  #identifiers dd.authors {
+    grid-area: -42 / 2 / -2 / 3;
   }
   #identifiers dd.authors .author {
     display: block;
     margin: 0;
+  }
+  #identifiers dd.internet-draft {
+    grid-area: -2 / 1 / -1 / 3;
+    display: block;
+    width: 72ch;
+    text-align: center;
+    margin: calc(4 * var(--line)) 0 calc(-5 * var(--line));
+  }
+  /* more overrides for @supports not block */
+  #identifiers dd:is(.published, .authors, .internet-draft)::before {
+    display: none;
   }
 }
 
 #title {
   clear: left;
   text-align: center;
-  margin-top: 2em;
+  margin: calc(2 * var(--line)) 3ch;
 }
 #rfcnum {
   display: none;


### PR DESCRIPTION
This puts the publication date in the right column and the draft name under the title.

Two flaws:

1. If the list of authors is shorter than the metadata, the publication date appears after the metadata, which looks odd.
2. If the title of a draft takes two lines, the draft name overwrites it.

Both of these are broken enough that this can't really be deployed, but it is fun when it works well.

One possible fix for (1) is to move it to the top of the righthand column.  That is easy, even if it is not consistent with existing RFC text formatting.  I have no idea of what might be done about (2).